### PR TITLE
Update 02-ShellScripting.ipynb

### DIFF
--- a/notebooks/02-ShellScripting.ipynb
+++ b/notebooks/02-ShellScripting.ipynb
@@ -292,7 +292,7 @@
     "\n",
     "1.  Explicit declaration: `MYVAR=myvalue`\n",
     "2.  Reading from the user: `read MYVAR`\n",
-    "3.  Command substitution: `MYVAR=\\$( (ls | wc -l) )`\n",
+    "3.  Command substitution: `MYVAR=\$( (ls | wc -l) )`\n",
     "\n",
     "Here are some examples of assignments (try them out and save as a single  `Week1/Code/variables.sh` script):\n",
     "\n",


### PR DESCRIPTION
Remove extra backslash in the example for "command substitution"

@mhasoba The extra backslash didn't work in my bash (Ubuntu 19.04):

```
$ MYVAR=\$( (ls | wc -l) )
bash: syntax error near unexpected token `('
$ MYVAR=\$((ls | wc -l))
bash: syntax error near unexpected token `('
$ MYVAR=\$(ls | wc -l)
bash: syntax error near unexpected token `('
```
...but without the backslash:
```
$ MYVAR=$( (ls | wc -l) )
(base) mathemage@mathemage-ThinkPad-E550:~/prog/mathemage/TheMulQuaBio/QMEECourseWork/Week1/SandBox$ echo $MYVAR
4
```

(but not sure how it's on Macs...)