### PR TITLE
Mention terminology of "push access"

### DIFF
--- a/notebooks/03-Git.ipynb
+++ b/notebooks/03-Git.ipynb
@@ -1221,7 +1221,7 @@
     "\n",
     "* The only practical submission for git is pushing your coursework git repository, `.gitgnore` and `readme` files included. Make sure your `.gitignore` has meaningful exclusions, and your `readme` has useful information. Google \"readme good practices\" or something like that to find online tips. \n",
     " \n",
-    "* Also, invite your assessor to your coursework repository (e.g, `CMEECourseWork`) repository with *write privileges*. The current assessor is s.pawar@imperial.ac.uk (or \"mhasoba\" on both bitbucket and github). \n",
+    "* Also, invite your assessor to your coursework repository (e.g, `CMEECourseWork`) repository with *write privileges* (also called *push access* in some versions of GitHub). The current assessor is s.pawar@imperial.ac.uk (or \"mhasoba\" on both bitbucket and github). \n",
     "\n",
     "Also, remember, you can clone TheMulQuaBio (see the [Intro Chapter](00-Intro.ipynb)). You can then `cp` files from this to your own CMEECourseWork as and when needed. Please don't work in the master repo, as you will lose your work when I next update it!\n",
     "\n",


### PR DESCRIPTION
In GitHub, the write privileges are called push access. It is more clear to mention it.

![Write privelege called as "push access" on GitHub](https://user-images.githubusercontent.com/3373514/66038652-a6a86c00-e50a-11e9-9106-4bfb1d84bae4.png)
by @mathemage 

